### PR TITLE
+ Add file for coder owners & GitHub Actions for CI (Tests)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,13 @@
+# Lines starting with '#' are comments.
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in the repo.
+*       @PikachuEXE
+
+# Order is important. The last matching pattern has the most precedence.
+# So if a pull request only touches javascript files, only these owners
+# will be requested to review.
+# *.rb    @PikachuEXE
+
+# You can also use email addresses if you prefer.
+# docs/*  docs@example.com

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,42 @@
+name: Tests
+
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+
+jobs:
+  unit_tests:
+    name: Unit Tests
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu
+        ruby:
+          - 2.4
+          - 2.5
+          - 2.6
+          - 2.7
+          - ruby-head
+        gemfile:
+          - gemfiles/contracts_15_0.gemfile
+          - gemfiles/contracts_16_0.gemfile
+    runs-on: ${{ matrix.os }}-latest
+    continue-on-error: ${{ endsWith(matrix.ruby, 'head') || matrix.ruby == 'debug' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+      - name: Bundle Install
+        run: |
+          export BUNDLE_GEMFILE="${GITHUB_WORKSPACE}/${{ matrix.gemfile }}"
+          bundle install --jobs 4 --retry 3
+      - name: Test
+        run: bundle exec rake


### PR DESCRIPTION
References
- https://technology.customink.com/blog/2019/09/02/from-travis-ci-to-github-actions/
- https://github.com/actions/runner/issues/2347
- https://github.com/amazing-print/amazing_print/pull/61 (Example for using `continue-on-error` to replace `allow_failures`)